### PR TITLE
update routes.jsx to correctly load ./components/homePage

### DIFF
--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -5,7 +5,7 @@ import React from 'react';
 /*eslint-enable */
 import {DefaultRoute, Route, NotFoundRoute, Redirect} from 'react-router';
 import App from './components/app';
-import HomePage from './components/HomePage';
+import HomePage from './components/homePage';
 import AuthorPage from './components/authors/authorPage';
 import ManageAuthorPage from './components/authors/manageAuthorPage';
 import AboutPage from './components/about/aboutPage';


### PR DESCRIPTION
As referenced in Issue https://github.com/arcseldon/react-babel-webpack-starter-app/issues/2 there is a small typo in `src/routes.jsx` that prevents `npm run build` from running correctly.

I've made a small change to fix this error